### PR TITLE
Fix name of repo in go.mod

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,3 +1,3 @@
-module github.com/pulumi/pulumi-proxmox/sdk
+module github.com/ryan4yin/pulumi-proxmox/sdk
 
 go 1.15


### PR DESCRIPTION
This fixes a tiny mistake in the go.mod file which caused Go to fail to download the SDK.